### PR TITLE
fix: No module named 'moviepy.editor'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     {name = "wushuhong", email = "wushuhong@atomgradient.com"},
 ]
 dependencies = [
-    "moviepy>=1.0.3",
+    "moviepy>=2.0.0,<3.0.0",
     "pytube>=15.0.0",
     "mlx>=0.0.5",
     "numba>=0.58.1",

--- a/src/whisper_mps/utils/ytdownloader.py
+++ b/src/whisper_mps/utils/ytdownloader.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from typing import Optional
 import sys
-from moviepy.editor import AudioFileClip
+from moviepy import AudioFileClip
 from pytube import YouTube
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 


### PR DESCRIPTION
* Upgraded `moviepy` to moviepy>=2.0.0,<3.0.0
* Import `AudioFileClip` directly from `moviepy` as `editor` namespace has been removed as per https://zulko.github.io/moviepy/getting_started/updating_to_v2.html