### PR TITLE
add model convertor to convert sft to .pt format

### DIFF
--- a/src/whisper_mps/utils/README_CONVERTOR.md
+++ b/src/whisper_mps/utils/README_CONVERTOR.md
@@ -1,0 +1,89 @@
+# HuggingFace Safetensors → whisper-mps `.pt` Converter
+
+Converts a HuggingFace Whisper model (`.safetensors`) into the OpenAI-style `.pt` checkpoint format expected by [whisper-mps](https://github.com/explodingcamera/whisper-mps).
+
+---
+
+## Requirements
+
+```bash
+pip install torch safetensors
+```
+
+---
+
+## Usage
+
+**1. Set the model path**
+
+Open `sftensores-to-dot-pt.py` and update `MODEL_PATH` to point to your `.safetensors` file:
+
+```python
+MODEL_PATH = "path/to/your/model.safetensors"
+```
+
+For example:
+```python
+MODEL_PATH = "../models/Whisper-ble/model.safetensors"
+```
+
+**2. Run the script**
+
+```bash
+python utils/sftensores-to-dot-pt.py
+```
+
+**3. Output**
+
+The script prints the detected model dimensions and saves `your-model.pt` in the current directory:
+
+```
+Detected dims: {'n_mels': 128, 'n_vocab': 51866, 'n_audio_ctx': 1500, ...}
+Saved your-model.pt
+```
+
+Move the output file to wherever whisper-mps expects your models:
+
+```bash
+mv your-model.pt ../models/
+```
+
+---
+
+## What it does
+
+HuggingFace Whisper checkpoints use different key names than the original OpenAI Whisper architecture. This script remaps them:
+
+| HuggingFace key | OpenAI / whisper-mps key |
+|---|---|
+| `model.encoder.layers.*` | `encoder.blocks.*` |
+| `model.encoder.layer_norm.*` | `encoder.ln_post.*` |
+| `model.encoder.embed_positions.weight` | `encoder.positional_embedding` |
+| `model.decoder.layers.*` | `decoder.blocks.*` |
+| `model.decoder.layer_norm.*` | `decoder.ln.*` |
+| `model.decoder.embed_positions.weight` | `decoder.positional_embedding` |
+| `model.decoder.embed_tokens.weight` | `decoder.token_embedding.weight` |
+| `*.self_attn.q/k/v_proj.*` | `*.attn.query/key/value.*` |
+| `*.encoder_attn.q/k/v_proj.*` | `*.cross_attn.query/key/value.*` |
+| `*.fc1.* / *.fc2.*` | `*.mlp.0.* / *.mlp.2.*` |
+| `*.final_layer_norm.*` | `*.mlp_ln.*` |
+
+It also auto-detects model dimensions (layer count, head count, state size) from the checkpoint itself, so it works across different Whisper model sizes without any manual configuration.
+
+---
+
+## Compatibility
+
+Tested with **Whisper v3 variants** (e.g. `openai/whisper-large-v3`, fine-tunes based on it).
+
+> **Note:** `n_mels=128` and `n_text_ctx=448` are hardcoded for Whisper v3. If you're using an older Whisper variant (v1/v2), you may need to change these to `n_mels=80` and `n_text_ctx=448` respectively.
+
+---
+
+## Troubleshooting
+
+**`FileNotFoundError`** — The path in `MODEL_PATH` is wrong. Double-check it points to an existing `.safetensors` file.
+
+**`KeyError: encoder.blocks.0.attn.query.weight`** — The key remapping didn't produce the expected keys. Your model may use a different HF architecture variant. Open an issue with the output of `print(list(hf_sd.keys())[:10])`.
+
+**Unexpected dims** — If the detected `n_heads` looks wrong, the model may not use 64-dim-per-head. Check `n_audio_state` and adjust the `n_heads = n_audio_state // 64` line accordingly.

--- a/src/whisper_mps/utils/sftensores-to-dot-pt.py
+++ b/src/whisper_mps/utils/sftensores-to-dot-pt.py
@@ -1,0 +1,100 @@
+# import torch
+# from safetensors.torch import load_file
+
+# # Load the safetensors file
+# state_dict = load_file("../models/""address-to-asr-model""/your-model.safetensors")
+
+# # Save as .pt
+# torch.save(state_dict, "your-model.pt")
+
+
+import torch
+from safetensors.torch import load_file
+
+
+MODEL_PATH = "path/to/your/model.safetensors"
+
+try:
+    hf_sd = load_file(MODEL_PATH)
+except FileNotFoundError:
+    print(f"Error: Model file not found at {MODEL_PATH}")
+    print("Please update MODEL_PATH to point to your .safetensors file")
+    exit(1)
+
+def remap_keys(hf_sd):
+    new_sd = {}
+    for k, v in hf_sd.items():
+        # strip leading "model."
+        k = k.removeprefix("model.")
+
+        # encoder
+        k = k.replace("encoder.layers.", "encoder.blocks.")
+        k = k.replace("encoder.layer_norm.", "encoder.ln_post.")
+        k = k.replace("encoder.embed_positions.weight", "encoder.positional_embedding")
+
+        # decoder
+        k = k.replace("decoder.layers.", "decoder.blocks.")
+        k = k.replace("decoder.layer_norm.", "decoder.ln.")
+        k = k.replace("decoder.embed_positions.weight", "decoder.positional_embedding")
+        k = k.replace("decoder.embed_tokens.weight", "decoder.token_embedding.weight")
+
+        # attention projections (encoder self-attn)
+        k = k.replace(".self_attn.q_proj.", ".attn.query.")
+        k = k.replace(".self_attn.k_proj.", ".attn.key.")
+        k = k.replace(".self_attn.v_proj.", ".attn.value.")
+        k = k.replace(".self_attn.out_proj.", ".attn.out.")
+        k = k.replace(".self_attn_layer_norm.", ".attn_ln.")
+
+        # attention projections (decoder cross-attn)
+        k = k.replace(".encoder_attn.q_proj.", ".cross_attn.query.")
+        k = k.replace(".encoder_attn.k_proj.", ".cross_attn.key.")
+        k = k.replace(".encoder_attn.v_proj.", ".cross_attn.value.")
+        k = k.replace(".encoder_attn.out_proj.", ".cross_attn.out.")
+        k = k.replace(".encoder_attn_layer_norm.", ".cross_attn_ln.")
+
+        # MLP
+        k = k.replace(".fc1.", ".mlp.0.")
+        k = k.replace(".fc2.", ".mlp.2.")
+        k = k.replace(".final_layer_norm.", ".mlp_ln.")
+
+        new_sd[k] = v
+    return new_sd
+
+remapped = remap_keys(hf_sd)
+
+# Detect dims from encoder layer count
+n_encoder_layers = max(
+    int(k.split("encoder.blocks.")[1].split(".")[0])
+    for k in remapped if "encoder.blocks." in k
+) + 1
+n_decoder_layers = max(
+    int(k.split("decoder.blocks.")[1].split(".")[0])
+    for k in remapped if "decoder.blocks." in k
+) + 1
+
+# medium model (32 encoder layers detected from your error)
+n_audio_state = remapped["encoder.blocks.0.attn.query.weight"].shape[0]
+n_heads = n_audio_state // 64
+
+dims = {
+    "n_mels": 128,
+    "n_vocab": remapped["decoder.token_embedding.weight"].shape[0],
+    "n_audio_ctx": 1500,
+    "n_audio_state": n_audio_state,
+    "n_audio_head": n_heads,
+    "n_audio_layer": n_encoder_layers,
+    "n_text_ctx": 448,
+    "n_text_state": n_audio_state,
+    "n_text_head": n_heads,
+    "n_text_layer": n_decoder_layers,
+}
+
+print("Detected dims:", dims)
+
+checkpoint = {
+    "dims": dims,
+    "model_state_dict": remapped,
+}
+
+torch.save(checkpoint, "your-model.pt")
+print("Saved your-model.pt")


### PR DESCRIPTION
This PR introduces a conversion utility that transforms Hugging Face safetensors model files into the PyTorch .pt format compatible with OpenAI's Whisper implementation. The converter handles the complex task of remapping parameter names between the two different naming conventions.
